### PR TITLE
[Bug-1] TargetEnvironment 이름 중복 생성 방지 및 409 Conflict 처리

### DIFF
--- a/src/main/java/com/appcatalog/error/DataConflictException.java
+++ b/src/main/java/com/appcatalog/error/DataConflictException.java
@@ -1,0 +1,7 @@
+package com.appcatalog.error;
+
+public class DataConflictException extends RuntimeException {
+  public DataConflictException(String message) {
+    super(message);
+  }
+}

--- a/src/main/java/com/appcatalog/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/appcatalog/error/GlobalExceptionHandler.java
@@ -18,4 +18,9 @@ public class GlobalExceptionHandler {
   public ResponseEntity<String> handleJobNotFound(JobNotFoundException ex) {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());
   }
+
+  @ExceptionHandler(DataConflictException.class)
+  public ResponseEntity<String> handleDataConflict(DataConflictException ex) {
+    return ResponseEntity.status(HttpStatus.CONFLICT).body(ex.getMessage());
+  }
 }

--- a/src/main/java/com/appcatalog/target/TargetService.java
+++ b/src/main/java/com/appcatalog/target/TargetService.java
@@ -1,5 +1,6 @@
 package com.appcatalog.target;
 
+import com.appcatalog.error.DataConflictException;
 import com.appcatalog.error.TargetNotFoundException;
 import com.appcatalog.target.domain.TargetEnvironment;
 import com.appcatalog.target.domain.TargetEnvironmentRepository;
@@ -19,6 +20,9 @@ public class TargetService {
   /** 새로운 배포 대상을 생성 (Create) */
   @Transactional // 데이터를 변경하므로 쓰기 가능 트랜잭션 적용
   public TargetEnvironment createTarget(TargetEnvironment target) {
+    if (targetRepository.existsByName(target.getName())) {
+      throw new DataConflictException("Target already exists with name: " + target.getName());
+    }
     return targetRepository.save(target);
   }
 

--- a/src/main/java/com/appcatalog/target/domain/TargetEnvironmentRepository.java
+++ b/src/main/java/com/appcatalog/target/domain/TargetEnvironmentRepository.java
@@ -1,7 +1,11 @@
 package com.appcatalog.target.domain;
 
+import lombok.NonNull;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface TargetEnvironmentRepository extends JpaRepository<TargetEnvironment, Long> {}
+public interface TargetEnvironmentRepository extends JpaRepository<TargetEnvironment, Long> {
+
+  boolean existsByName(String name);
+}


### PR DESCRIPTION
### 📝 PR 요약

`TargetEnvironment`를 생성할 때, 이미 존재하는 `name`으로 요청이 들어올 경우 `HTTP 409 Conflict` 응답과 함께 적절한 에러 메시지를 반환하도록 예외 처리 로직을 구현했습니다. 이를 통해 데이터베이스의 데이터 무결성을 강화하고, 클라이언트에게 명확한 오류 피드백을 제공합니다.

---

### ✅ 주요 변경 사항

* `com.appcatalog.error.DataConflictException` 커스텀 예외 클래스 추가.
* `TargetEnvironmentRepository`에 `boolean existsByName(String name);` 메소드 추가.
* `TargetService.createTarget()` 메소드 내에 `existsByName`을 활용한 중복 검사 로직 추가 및 `DataConflictException` 발생.
* `GlobalExceptionHandler`에 `DataConflictException`을 처리하여 `HTTP Status 409 Conflict`를 반환하는 핸들러 추가.

---

### 🧪 테스트 결과

1.  Postman으로 `name: "My Unique VM"`으로 `TargetEnvironment`를 생성 요청 시 `201 Created` 확인.
2.  동일한 `name: "My Unique VM"`으로 `TargetEnvironment`를 다시 생성 요청 시 `409 Conflict` 응답과 "Target already exists with name: My Unique VM" 메시지 확인.

모든 테스트 케이스가 기대하는 대로 동작함을 확인했습니다.

---