### PR TITLE
feat: 대상 환경 유효성 검증 및 인증 정보 관리 기능 구현

### DIFF
--- a/src/main/java/com/appcatalog/credential/dto/CredentialRequestDto.java
+++ b/src/main/java/com/appcatalog/credential/dto/CredentialRequestDto.java
@@ -1,0 +1,28 @@
+package com.appcatalog.credential.dto;
+
+import com.appcatalog.credential.Credential;
+
+import jakarta.validation.constraints.NotBlank;
+
+import lombok.AllArgsConstructor;
+
+import lombok.Data;
+
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class CredentialRequestDto {
+
+  @NotBlank(message = "Username cannot be empty")
+  private String username;
+
+  @NotBlank(message = "Password cannot be empty")
+  private String password;
+
+  public Credential toEntity() {
+
+    return Credential.builder().username(this.username).password(this.password).build();
+  }
+}

--- a/src/main/java/com/appcatalog/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/appcatalog/error/GlobalExceptionHandler.java
@@ -2,13 +2,31 @@ package com.appcatalog.error;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
 
 @RestControllerAdvice // 이 클래스가 모든 컨트롤러의 예외를 담당
 public class GlobalExceptionHandler {
 
-  // TargetNotFoundException 이 들어오면, 이 메소드를 실행
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  public ResponseEntity<Map<String, String>> handleValidationExceptions(
+      MethodArgumentNotValidException ex) {
+    Map<String, String> errors = new HashMap<>();
+    ex.getBindingResult()
+        .getFieldErrors()
+        .forEach(
+            error -> {
+              String fieldName = error.getField(); // 오류가 발생한 필드 이름
+              String errorMessage = error.getDefaultMessage(); // 오류 메시지
+              errors.put(fieldName, errorMessage);
+            });
+    return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(errors);
+  }
+
   @ExceptionHandler(TargetNotFoundException.class)
   public ResponseEntity<String> handleTargetNotFound(TargetNotFoundException ex) {
     return ResponseEntity.status(HttpStatus.NOT_FOUND).body(ex.getMessage());

--- a/src/main/java/com/appcatalog/target/TargetController.java
+++ b/src/main/java/com/appcatalog/target/TargetController.java
@@ -1,6 +1,8 @@
 package com.appcatalog.target;
 
 import com.appcatalog.target.domain.TargetEnvironment;
+import com.appcatalog.target.dto.TargetRequestDto;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,8 +19,9 @@ public class TargetController {
 
   // --- 생성 API ---
   @PostMapping
-  public ResponseEntity<TargetEnvironment> createTarget(@RequestBody TargetEnvironment newTarget) {
-    TargetEnvironment createdTarget = targetService.createTarget(newTarget);
+  public ResponseEntity<TargetEnvironment> createTarget(
+      @RequestBody @Valid TargetRequestDto newTarget) {
+    TargetEnvironment createdTarget = targetService.createTarget(newTarget.toEntity());
     return ResponseEntity.status(HttpStatus.CREATED).body(createdTarget); // 201 Created
   }
 
@@ -38,8 +41,8 @@ public class TargetController {
   // --- 수정 API ---
   @PutMapping("/{id}")
   public ResponseEntity<TargetEnvironment> updateTargetById(
-      @PathVariable Long id, @RequestBody TargetEnvironment updatedTarget) {
-    TargetEnvironment target = targetService.updateTarget(id, updatedTarget);
+      @PathVariable Long id, @RequestBody @Valid TargetRequestDto updatedTarget) {
+    TargetEnvironment target = targetService.updateTarget(id, updatedTarget.toEntity());
     return ResponseEntity.ok(target); // 200 OK
   }
 

--- a/src/main/java/com/appcatalog/target/TargetService.java
+++ b/src/main/java/com/appcatalog/target/TargetService.java
@@ -47,7 +47,7 @@ public class TargetService {
     existingTarget.setType(updatedDetails.getType());
     existingTarget.setHost(updatedDetails.getHost());
     existingTarget.setPort(updatedDetails.getPort());
-    existingTarget.setCredentialId(updatedDetails.getCredentialId());
+    existingTarget.setCredential(updatedDetails.getCredential());
 
     return targetRepository.save(existingTarget);
   }

--- a/src/main/java/com/appcatalog/target/domain/TargetEnvironment.java
+++ b/src/main/java/com/appcatalog/target/domain/TargetEnvironment.java
@@ -1,5 +1,6 @@
 package com.appcatalog.target.domain;
 
+import com.appcatalog.credential.Credential;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
@@ -21,5 +22,10 @@ public class TargetEnvironment {
 
   private String host; // 실제 서버 호스트
   private int port; // 서버 포트
-  private String credentialId; // 인증 정보 ID
+
+  // TargetEnvironment가 저장/삭제 시 Credential도 같이 저장/삭제 되도록 설정
+  @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+  // 외래키 컬럼명 지정
+  @JoinColumn(name = "credential_id", referencedColumnName = "id")
+  private Credential credential; // 인증 정보 ID
 }

--- a/src/main/java/com/appcatalog/target/dto/TargetRequestDto.java
+++ b/src/main/java/com/appcatalog/target/dto/TargetRequestDto.java
@@ -1,32 +1,41 @@
 package com.appcatalog.target.dto;
 
+import com.appcatalog.credential.dto.CredentialRequestDto;
 import com.appcatalog.target.domain.TargetEnvironment;
-import jakarta.validation.constraints.NotBlank;
+import com.appcatalog.target.domain.TargetType;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.*;
 import lombok.Data;
 
 @Data
 public class TargetRequestDto {
   @NotBlank(message = "Target name cannot be empty")
+  @Size(min = 2, max = 50, message = "Target name must be between 2 and 50 characters")
   private String name;
 
-  private String type;
+  @NotNull(message = "Target type cannot be empty")
+  private TargetType type;
 
   @NotBlank(message = "Target name cannot be empty")
   private String host;
 
-  @NotBlank(message = "Target name cannot be empty")
+  @Min(value = 1, message = "Port must be at least 1")
+  @Max(value = 65535, message = "Port must be at most 65535")
   private int port;
 
-  private String credentialId;
+  @Valid
+  @NotNull(message = "Credential cannot be empty")
+  private CredentialRequestDto credential;
 
   public TargetEnvironment toEntity() {
     TargetEnvironment targetEnvironment = new TargetEnvironment();
     targetEnvironment.setName(this.name);
-    targetEnvironment.setType(
-        com.appcatalog.target.domain.TargetType.valueOf(this.type.toUpperCase()));
+    targetEnvironment.setType(this.type);
     targetEnvironment.setHost(this.host);
     targetEnvironment.setPort(this.port);
-    targetEnvironment.setCredentialId(this.credentialId);
+    if (this.credential != null) {
+      targetEnvironment.setCredential(this.credential.toEntity());
+    }
     return targetEnvironment;
   }
 }

--- a/src/test/java/com/appcatalog/target/TargetServiceTest.java
+++ b/src/test/java/com/appcatalog/target/TargetServiceTest.java
@@ -1,5 +1,6 @@
 package com.appcatalog.target;
 
+import com.appcatalog.credential.Credential;
 import com.appcatalog.error.TargetNotFoundException;
 import com.appcatalog.target.domain.TargetEnvironment;
 import com.appcatalog.target.domain.TargetEnvironmentRepository;
@@ -118,19 +119,23 @@ class TargetServiceTest {
     // given
     Long targetId = 1L;
     TargetEnvironment existingTarget = new TargetEnvironment();
+    Credential oldCredential =
+        Credential.builder().username("old_user").password("old_pass").build();
     existingTarget.setId(targetId);
     existingTarget.setName("Old Name");
     existingTarget.setType(TargetType.VM);
     existingTarget.setHost("old.host.com");
     existingTarget.setPort(8080);
-    existingTarget.setCredentialId("old_cred");
+    existingTarget.setCredential(oldCredential);
 
     TargetEnvironment updatedDetails = new TargetEnvironment();
+    Credential newCredential =
+        Credential.builder().username("new_user").password("new_pass").build();
     updatedDetails.setName("New Name");
     updatedDetails.setType(TargetType.KUBERNETES);
     updatedDetails.setHost("new.host.com");
     updatedDetails.setPort(9090);
-    updatedDetails.setCredentialId("new_cred");
+    updatedDetails.setCredential(newCredential);
 
     given(targetRepository.findById(targetId)).willReturn(Optional.of(existingTarget));
     given(targetRepository.save(any(TargetEnvironment.class))).willReturn(existingTarget);
@@ -145,7 +150,10 @@ class TargetServiceTest {
     assertThat(result.getType()).isEqualTo(updatedDetails.getType());
     assertThat(result.getHost()).isEqualTo(updatedDetails.getHost());
     assertThat(result.getPort()).isEqualTo(updatedDetails.getPort());
-    assertThat(result.getCredentialId()).isEqualTo(updatedDetails.getCredentialId());
+    assertThat(result.getCredential().getUsername())
+        .isEqualTo(updatedDetails.getCredential().getUsername());
+    assertThat(result.getCredential().getPassword())
+        .isEqualTo(updatedDetails.getCredential().getPassword());
   }
 
   @DisplayName("존재하지 않는 ID로 Target을 수정하면, 예외를 던진다.")


### PR DESCRIPTION
### 요약
배포 대상 환경(`TargetEnvironment`) 생성 및 수정 시 데이터 유효성을 강화하고, 대상 환경에 연결될 인증 정보(`Credential`)를 독립적으로 관리할 수 있는 기능을 구현했습니다.

### 변경 사항

1.  **`Credential` 엔티티 및 관련 컴포넌트 추가**
    * `Credential` 엔티티: 배포 대상 환경에 접근하기 위한 인증 정보(예: 사용자 이름, 비밀번호)를 저장합니다.
    * `CredentialRepository`: `Credential` 엔티티의 데이터베이스 CRUD 작업을 담당합니다.
    * `CredentialRequestDto`, `CredentialResponseDto`: `Credential` 정보의 요청 및 응답 시 데이터 전송 객체입니다.
    * `CredentialService`: `Credential` 비즈니스 로직을 처리합니다.

2.  **`TargetEnvironment`와 `Credential` 간의 관계 설정**
    * `TargetEnvironment` 엔티티에 `Credential` 엔티티와의 `@OneToOne` 관계를 설정했습니다. (Cascade Type은 `ALL`로 설정하여 `TargetEnvironment` 삭제 시 `Credential`도 함께 삭제되도록 합니다.)

3.  **데이터 유효성 검증 (`jakarta.validation` 적용)**
    * `TargetRequestDto` 및 `CredentialRequestDto`에 `@Valid`, `@NotNull`, `@NotBlank`, `@Min`, `@Max` 등의 `@jakarta.validation` 어노테이션을 적용하여 클라이언트 요청 데이터에 대한 강력한 유효성 검증을 구현했습니다.
        * `TargetRequestDto`의 `port` 필드에 `int` 타입에 맞게 `@NotBlank` 대신 `@Min`, `@Max` 유효성 검증을 사용하도록 수정했습니다.
    * 유효성 검증 실패 시 `MethodArgumentNotValidException`을 처리하는 `GlobalExceptionHandler`를 구현하여 일관된 에러 응답을 제공합니다.

4.  **테스트 코드 업데이트**
    * `TargetServiceTest`의 테스트 케이스를 `Credential`을 포함하도록 업데이트하고, 유효성 검증 시나리오를 추가하여 변경된 로직의 견고성을 확인했습니다.

### 주요 변경 파일

* `src/main/java/com/appcatalog/credential/Credential.java` (신규)
* `src/main/java/com/appcatalog/credential/CredentialRepository.java` (신규)
* `src/main/java/com/appcatalog/credential/CredentialService.java` (신규)
* `src/main/java/com/appcatalog/credential/dto/CredentialRequestDto.java` (신규)
* `src/main/java/com/appcatalog/credential/dto/CredentialResponseDto.java` (신규)
* `src/main/java/com/appcatalog/target/TargetEnvironment.java` (수정)
* `src/main/java/com/appcatalog/target/dto/TargetRequestDto.java` (수정)
* `src/main/java/com/appcatalog/target/TargetService.java` (수정)
* `src/main/java/com/appcatalog/global/GlobalExceptionHandler.java` (수정/추가)
* `src/test/java/com/appcatalog/target/TargetServiceTest.java` (수정)
* `src/main/resources/application.properties` (데이터베이스 연결 정보 확인)
* `docker-compose.yml` (PostgreSQL 환경 변수 확인)

### 테스트 방법

1.  `docker-compose up --build` 명령어로 애플리케이션 및 데이터베이스를 실행합니다.
2.  다음과 같은 요청을 통해 `TargetEnvironment` 및 `Credential` 생성/수정 API를 테스트합니다. (예: Postman, curl)

    **POST /api/targets (유효한 요청 예시):**
    ```json
    {
      "name": "My Prod Server",
      "type": "SERVER",
      "host": "prod.mycompany.com",
      "port": 22,
      "credential": {
        "username": "prod_user",
        "password": "prod_password"
      }
    }
    ```

    **POST /api/targets (유효성 검증 실패 예시):**
    * `name`이 비어 있거나 `port`가 유효 범위(1~65535) 밖이거나 `credential`이 누락된 경우 등
    * 적절한 HTTP 상태 코드(예: 400 Bad Request)와 함께 상세한 에러 메시지가 반환되는지 확인합니다.